### PR TITLE
Parsing of the message ID 90 (report power status)

### DIFF
--- a/index.js
+++ b/index.js
@@ -314,6 +314,39 @@ module.exports = class Client
 							}
 						}
 					}
+                    else if(line.includes(`${destAddress}:90:`))
+                    {
+						var logicalAddress = line.substring(line.indexOf('>> ') + 3, line.indexOf(`${destAddress}:90:`));
+						if(logicalAddress && logicalAddress.length === 1)
+						{
+							ctl_debug('Received report current power status request');
+							var lineCmd = line.split('>> ')[1];
+
+							if(this.devices.hasOwnProperty('dev' + logicalAddress))
+							{
+								var pwrSta = lineCmd.substring(lineCmd.indexOf(`${destAddress}:90:`) + 5, lineCmd.length);
+
+								if(pwrSta.length === 2)
+								{
+									var newPwrSta = '';
+
+									switch (pwrSta)
+									{
+										case '00': newPwrSta = 'on'
+										case '01': newPwrSta = 'standby'
+										case '02': newPwrSta = 'in transition from standby to on'
+										case '03': newPwrSta = 'in transition from on to standby'
+									}
+
+									if(newPwrSta!='')
+									{
+										this.devices['dev' + logicalAddress].powerStatus = newPwrSta;
+										ctl_debug(`Updated dev${logicalAddress} powerStatus to: ${newPwrSta}`);
+									}
+								}
+							}
+						}
+                    }
 				}
 				else if(line.includes('<<') && !this.togglingPower)
 				{

--- a/index.js
+++ b/index.js
@@ -229,6 +229,7 @@ module.exports = class Client
 			if(line.includes('>>'))
 			{
 				var destAddress = this.devices[this.myDevice].logicalAddress;
+				ctl_debug('destAddress' + destAddress);
 				var value = this._getLineValue(line).toUpperCase();
 
 				if(line.includes(`>> 0${destAddress}:44:`))
@@ -288,8 +289,8 @@ module.exports = class Client
 						if(line.includes(`>> ${logicalAddress}f:84:`))
 							this._checkDevicesStatus(`dev${logicalAddress}`);
 					}
-                    else if(line.includes(`${destAddress}:90:`))
-                    {
+					else if(line.includes(`${destAddress}:90:`))
+					{
 						var logicalAddress = line.substring(line.indexOf('>> ') + 3, line.indexOf(`${destAddress}:90:`));
 						if(logicalAddress && logicalAddress.length === 1)
 						{
@@ -306,10 +307,10 @@ module.exports = class Client
 
 									switch (pwrSta)
 									{
-										case '00': newPwrSta = 'on'
-										case '01': newPwrSta = 'standby'
-										case '02': newPwrSta = 'in transition from standby to on'
-										case '03': newPwrSta = 'in transition from on to standby'
+										case '00': newPwrSta = 'on'; break;
+										case '01': newPwrSta = 'standby'; break;
+										case '02': newPwrSta = 'in transition from standby to on'; break;
+										case '03': newPwrSta = 'in transition from on to standby'; break;
 									}
 
 									if(newPwrSta!='')
@@ -320,7 +321,7 @@ module.exports = class Client
 								}
 							}
 						}
-                    }
+					}
 				}
 				else if(line.includes('f:82:'))
 				{


### PR DESCRIPTION
With the Message ID `8F` the current power status of a device can be determined. Using the command `command('tx 40:8F')`, for example, the status of the TV sets can be requested.

At the moment the response message is not parsed and not transferred in the `powerStatus`. By parsing the message with the ID 90 the current status after an active request will also be displayed correctly in the `powerStatus`.